### PR TITLE
Quick create `ignore.txt` file

### DIFF
--- a/illumina_uploader/database.py
+++ b/illumina_uploader/database.py
@@ -90,7 +90,7 @@ class Database:
 
     def createIgnoreFile(self):
         for d in self.inputDirs:
-            collectIgnoreList(d)
+            collectIgnoreList(d, self.folderRegex, self.logger)
 
     def _insertFolders(self, folderName):
         '''

--- a/illumina_uploader/database.py
+++ b/illumina_uploader/database.py
@@ -88,6 +88,17 @@ class Database:
         for folder in folders:
             print(','.join(folder))
 
+    def createIgnoreFile(self, input_path):
+        existing_directories = []
+        for f in os.listdir(input_path):
+            if os.path.isdir(os.path.join(input_path, f)):
+                existing_directories.append(f)
+
+        ignorefile_path = os.path.join(os.path.dirname(self.location), "ignore.txt")
+        with open(ignorefile_path, 'w') as f:
+            for d in existing_directories:
+                f.write(d + '\n')
+
     def _insertFolders(self, folderName):
         '''
         Internal function for inserting folder data into db

--- a/illumina_uploader/database.py
+++ b/illumina_uploader/database.py
@@ -7,7 +7,7 @@ import sys
 from datetime import datetime
 from shutil import copyfile
 
-from .utils import regenIgnoreList, Run
+from .utils import regenIgnoreList, collectIgnoreList, Run
 
 
 class Database:
@@ -88,16 +88,9 @@ class Database:
         for folder in folders:
             print(','.join(folder))
 
-    def createIgnoreFile(self, input_path):
-        existing_directories = []
-        for f in os.listdir(input_path):
-            if os.path.isdir(os.path.join(input_path, f)):
-                existing_directories.append(f)
-
-        ignorefile_path = os.path.join(os.path.dirname(self.location), "ignore.txt")
-        with open(ignorefile_path, 'w') as f:
-            for d in existing_directories:
-                f.write(d + '\n')
+    def createIgnoreFile(self):
+        for d in self.inputDirs:
+            collectIgnoreList(d)
 
     def _insertFolders(self, folderName):
         '''

--- a/illumina_uploader/illumina_uploader.py
+++ b/illumina_uploader/illumina_uploader.py
@@ -26,7 +26,7 @@ def main():
     parser.add_argument("--create-db", action="store_true", help="initialise sqlite database")
     parser.add_argument("--backup-db", action="store_true", help="backup sqlite database")
     parser.add_argument("--print-db", action="store_true", help="print sqlite database to stdout")
-    parser.add_argument("--create-ignorefile", help="create an ingore.txt file based on the contents of a directory")
+    parser.add_argument("--create-ignorefile", action="store_true", help="create an ignore.txt file based on the current contents of the input directories")
     parser.add_argument("--dry-run", action="store_true", help="mock upload testing without uploading anything [NOT IMPLEMENTED YET]")
     parser.add_argument("--debug", action="store_true", help="print debug data and not send out emails")
     args = parser.parse_args()
@@ -77,7 +77,7 @@ def main():
         dbObject.printDb()
         exit(0)
     if args.create_ignorefile:
-        dbObject.createIgnoreFile(args.create_ignorefile)
+        dbObject.createIgnoreFile()
         exit(0)
 
     try:

--- a/illumina_uploader/illumina_uploader.py
+++ b/illumina_uploader/illumina_uploader.py
@@ -26,6 +26,7 @@ def main():
     parser.add_argument("--create-db", action="store_true", help="initialise sqlite database")
     parser.add_argument("--backup-db", action="store_true", help="backup sqlite database")
     parser.add_argument("--print-db", action="store_true", help="print sqlite database to stdout")
+    parser.add_argument("--create-ignorefile", help="create an ingore.txt file based on the contents of a directory")
     parser.add_argument("--dry-run", action="store_true", help="mock upload testing without uploading anything [NOT IMPLEMENTED YET]")
     parser.add_argument("--debug", action="store_true", help="print debug data and not send out emails")
     args = parser.parse_args()
@@ -74,6 +75,9 @@ def main():
         exit(0)
     if args.print_db:
         dbObject.printDb()
+        exit(0)
+    if args.create_ignorefile:
+        dbObject.createIgnoreFile(args.create_ignorefile)
         exit(0)
 
     try:

--- a/illumina_uploader/utils.py
+++ b/illumina_uploader/utils.py
@@ -1,4 +1,4 @@
-import os, logging, sys, pytz, time
+import os, logging, re, sys, pytz, time
 from logging.handlers import RotatingFileHandler
 from urllib.request import urlopen
 from datetime import datetime
@@ -83,25 +83,24 @@ def regenIgnoreList(inputDir):
     ignoreList = list(set(ignoreList)) #remove duplicate lines
     return ignoreList
 
-def collectIgnoreList(inputDir):
+def collectIgnoreList(inputDir, folder_regex, logger):
     '''
     Collect current folders into ignore.txt
     useful when setting up on new sequencer
     '''
     existing_run_directories = []
     for f in os.listdir(inputDir):
-        if os.path.isdir(os.path.join(inputDir, f)):
+        if os.path.isdir(os.path.join(inputDir, f)) and re.match(folder_regex, f):
             existing_run_directories.append(f)
 
     ignorefile_path = os.path.join(inputDir, "ignore.txt")
-    new_ignore_list = []
-    if os.path.isfile(ignorefile_path):
-        new_ignore_list += regenIgnoreList(inputDir)
-    new_ignore_list += existing_run_directories
-    new_ignore_list = sorted(set(new_ignore_list))
-    with open(ignorefile_path, 'w') as f:
-        for d in new_ignore_list:
-            f.write(d + '\n')
+    if not os.path.isfile(ignorefile_path):
+        with open(ignorefile_path, 'w') as f:
+            for d in existing_run_directories:
+                f.write(d + '\n')
+    else:
+        logger.info('File: ' + ignorefile_path + ' exists. New ignore.txt file not created.')
+                
 
 
 def addToList(inputDir, folderName, listType):

--- a/illumina_uploader/utils.py
+++ b/illumina_uploader/utils.py
@@ -72,7 +72,7 @@ def regenIgnoreList(inputDir):
     Refresh/regenerate ignore.txt file
     '''
     ignoreList = []
-    ignoreFileLoc = inputDir+"ignore.txt"
+    ignoreFileLoc = os.path.join(inputDir, "ignore.txt")
     if "ignore.txt" in os.listdir(inputDir):
         with open(ignoreFileLoc) as fileio:
             ignoreList = fileio.read().splitlines()
@@ -88,7 +88,21 @@ def collectIgnoreList(inputDir):
     Collect current folders into ignore.txt
     useful when setting up on new sequencer
     '''
-    pass
+    existing_run_directories = []
+    for f in os.listdir(inputDir):
+        if os.path.isdir(os.path.join(inputDir, f)):
+            existing_run_directories.append(f)
+
+    ignorefile_path = os.path.join(inputDir, "ignore.txt")
+    new_ignore_list = []
+    if os.path.isfile(ignorefile_path):
+        new_ignore_list += regenIgnoreList(inputDir)
+    new_ignore_list += existing_run_directories
+    new_ignore_list = sorted(set(new_ignore_list))
+    with open(ignorefile_path, 'w') as f:
+        for d in new_ignore_list:
+            f.write(d + '\n')
+
 
 def addToList(inputDir, folderName, listType):
     '''


### PR DESCRIPTION
Fixes #44 

Looks in each `inputDir` (as defined in `config.ini`), collects existing directories there. If an `ignore.txt` file is already present, then any additional directories in `inputDir` are added to that file. Otherwise, a new `ignore.txt` file is created with the current contents of the `inputDir`.

Each `ignore.txt` file is written to its respective `inputDir`.