### PR TITLE
No `upload_complete.json` when upload is interrupted

### DIFF
--- a/config.ini.template
+++ b/config.ini.template
@@ -22,8 +22,8 @@ mailsubject = [illumina-uploader] {status} miseq data transfer to sabin
 mailbody = Run directory {folderToUpload} {status} transferring to Sabin at {timeOfMail}
 
 [COMMANDS]
-rsynccommand = rsync -artvh -p -e "{sshformat} -i {pem}" {chmod} {inDir}{inFile} {login}@{host}:{outDir}
-scpcommand = scp -i {pem} {inDir}{filename} {login}@{host}:{outDir}{filename}
+rsynccommand = rsync -artvh -p -e "{sshformat} -i {pem}" {chmod} {inDir}/{inFile} {login}@{host}:{outDir}
+scpcommand = scp -i {pem} {inDir}/{filename} {login}@{host}:{outDir}/{filename}
 sshnixcommand = ssh
 sshwincommand = /usr/bin/ssh
 chmodcommand = --chmod=Du=rwx,Dg=rx,Fu=rw,Fg=r,o=

--- a/illumina_uploader/fabfile.py
+++ b/illumina_uploader/fabfile.py
@@ -63,8 +63,8 @@ def scpUploadCompleteJson(context, args):
         if args["inFile"] == possibleRun.name:
             actualInDir = possibleRun.inputDir
             actualOutDir = possibleRun.outputDir
-    args["inDir"] = "temp/"
-    args["outDir"] = actualOutDir + args["inFile"] + "/"
+    args["inDir"] =  os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp")
+    args["outDir"] = os.path.join(actualOutDir + args["inFile"])
     args["filename"] = "upload_complete.json"
     try:
         #Create upload_complete.json
@@ -74,7 +74,7 @@ def scpUploadCompleteJson(context, args):
             "timestamp_start": args["starttime"],
             "timestamp_end": now,
             "input_directory": os.path.join(actualInDir, args["inFile"]),
-            "output_directory": args["outDir"].rstrip('/'),
+            "output_directory": args["outDir"],
         }
         upload_complete_json_path = os.path.join(args["inDir"], args["filename"])
         with open(upload_complete_json_path, 'w') as f:

--- a/illumina_uploader/illumina_uploader.py
+++ b/illumina_uploader/illumina_uploader.py
@@ -157,6 +157,7 @@ def main():
                 sleeptimeInSeconds = int(localInfo["sleeptime"])*60
                 time.sleep(sleeptimeInSeconds)
     except FileNotFoundError as error:
+        logger.info(error)
         logger.info("Shutting down Directory Watch. Exiting.")
     
 

--- a/illumina_uploader/illumina_uploader.py
+++ b/illumina_uploader/illumina_uploader.py
@@ -145,7 +145,8 @@ def main():
                         logger.info("Marking in DB as {0}".format(status))
                         dbObject.markFileInDb(folderToUpload, status)
                         #Create json file
-                        scpUploadCompleteJson(context, runArgs)
+                        if isSuccessful:
+                            scpUploadCompleteJson(context, runArgs)
                         #Mail send after done, update subject and body
                         mailArgs["subject"] = emailInfo["mailsubject"].format(status=status)
                         mailArgs["body"] = emailInfo["mailbody"].format(folderToUpload=folderToUpload, status=status, timeOfMail=getDateTimeNow(), reason=reason)

--- a/illumina_uploader/tmp/upload_complete.json
+++ b/illumina_uploader/tmp/upload_complete.json
@@ -1,0 +1,6 @@
+{
+  "timestamp_start": "2021-11-05T13:37:57.227744-07:00",
+  "timestamp_end": "2021-11-05T13:38:09.184607-07:00",
+  "input_directory": "/home/dfornika/code/illumina-uploader/test_input/210927_M00325_0408_000000000-G9539",
+  "output_directory": "/scratch/dfornika/illumina-uploader-test/210927_M00325_0408_000000000-G9539"
+}


### PR DESCRIPTION
Fixes #36

Check that an upload is successful before sending the `upload_complete.json` file.

Note: A change was made to the `config.ini.template` file to ensure that path separators are included. Upload of `upload_complete.json` file fails otherwise. Existing configs will need to be updated to be compatible with this code.