### PR TITLE
Allow DB and DB backup path to be outside source dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ illumina-uploader --backup-db
 
 Delete database (useful for testing.. backup db first!)
 ```
-rm local.db
+rm /path/to/local.db
 ```
 
 Specify custom config and sequencer

--- a/illumina_uploader/database.py
+++ b/illumina_uploader/database.py
@@ -16,14 +16,27 @@ class Database:
     TODO replace with DjangoORM in future
     '''
     def __init__(self, dbInfo, queries, logger, inputDirs, folderRegex):
-        self.location = os.path.join(os.path.dirname(__file__), dbInfo["location"])
-        self.backups = os.path.join(os.path.dirname(__file__), dbInfo["backupfolder"])
-        self.folderTable = dbInfo["foldertable"]
-        self.connection = self.initConnection()
-        self.queries = queries
         self.logger = logger
+        self.location = os.path.join(os.path.dirname(__file__), dbInfo["location"])
+        self.backups = os.path.abspath(dbInfo["backupfolder"])
+        self.folderTable = dbInfo["foldertable"]
         self.inputDirs = inputDirs
+        self.queries = queries
         self.folderRegex = folderRegex
+        self.checkInputs()
+        self.connection = self.initConnection()
+
+
+    def checkInputs(self):
+        non_existent_inputs = []
+        for d in [os.path.dirname(self.location), self.backups] + self.inputDirs:
+            if not os.path.exists(d):
+                non_existent_inputs.append(d)
+
+        if len(non_existent_inputs) > 0:
+            for i in non_existent_inputs:
+                self.logger.error("File or directory does not exist: " + i + " Check config.ini file.")
+            exit(1)
 
     def initConnection(self):
         return sqlite3.connect(self.location)

--- a/illumina_uploader/database.py
+++ b/illumina_uploader/database.py
@@ -17,7 +17,7 @@ class Database:
     '''
     def __init__(self, dbInfo, queries, logger, inputDirs, folderRegex):
         self.logger = logger
-        self.location = os.path.join(os.path.dirname(__file__), dbInfo["location"])
+        self.location = os.path.abspath(dbInfo["location"])
         self.backups = os.path.abspath(dbInfo["backupfolder"])
         self.folderTable = dbInfo["foldertable"]
         self.inputDirs = inputDirs


### PR DESCRIPTION
Fixes #50
Fixes #52

Allow backups to be stored  in arbitrary directories.

Check that input directories exist when initializing database object. If not, log error message and exit.